### PR TITLE
vertically align stat boxes on time breakdown page

### DIFF
--- a/docs/_sass/_layout.scss
+++ b/docs/_sass/_layout.scss
@@ -360,11 +360,12 @@ pre code.hljs {
 		flex-shrink: 1;
 	}
 
-	#stat-card-flex {
-		height: 100%;
-		flex-grow: 15;
-		flex-shrink: 1;
-		align-self: baseline;
+	.stat-card-flex {
+		.stat-card {
+			height: 100%;
+			text-align: center;
+			justify-content: center;
+		}
 	}
 
 	/* Mobile view */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7595121/174658384-dda28fa3-6929-466a-ac76-6594d421908d.png)
